### PR TITLE
add callbacks for all major websocket connection events

### DIFF
--- a/src/main/java/com/binance/connector/client/WebsocketClient.java
+++ b/src/main/java/com/binance/connector/client/WebsocketClient.java
@@ -5,18 +5,31 @@ import java.util.ArrayList;
 
 public interface WebsocketClient {
     int aggTradeStream(String symbol, WebSocketCallback callback);
+    int aggTradeStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int tradeStream(String symbol, WebSocketCallback callback);
+    int tradeStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int klineStream(String symbol, String interval, WebSocketCallback callback);
+    int klineStream(String symbol, String interval, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int miniTickerStream(String symbol, WebSocketCallback callback);
+    int miniTickerStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int allMiniTickerStream(WebSocketCallback callback);
+    int allMiniTickerStream(WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int symbolTicker(String symbol, WebSocketCallback callback);
+    int symbolTicker(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int allTickerStream(WebSocketCallback callback);
+    int allTickerStream(WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int bookTicker(String symbol, WebSocketCallback callback);
+    int bookTicker(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int allBookTickerStream(WebSocketCallback callback);
+    int allBookTickerStream(WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int partialDepthStream(String symbol, int levels, int speed, WebSocketCallback callback);
+    int partialDepthStream(String symbol, int levels, int speed, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int diffDepthStream(String symbol, int speed, WebSocketCallback callback);
+    int diffDepthStream(String symbol, int speed, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int listenUserStream(String listenKey, WebSocketCallback callback);
+    int listenUserStream(String listenKey, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     int combineStreams(ArrayList<String> streams, WebSocketCallback callback);
+    int combineStreams(ArrayList<String> streams, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback);
     void closeConnection(int streamId);
     void closeAllConnections();
 }

--- a/src/main/java/com/binance/connector/client/impl/WebsocketClientImpl.java
+++ b/src/main/java/com/binance/connector/client/impl/WebsocketClientImpl.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 public class WebsocketClientImpl implements WebsocketClient {
     private final String baseUrl;
     private final Map<Integer, WebSocketConnection> connections = new HashMap<>();
+    private final WebSocketCallback noopCallback = msg -> {};
     private static final Logger logger = LoggerFactory.getLogger(WebsocketClientImpl.class);
 
     public WebsocketClientImpl() {
@@ -36,8 +37,7 @@ public class WebsocketClientImpl implements WebsocketClient {
     public WebsocketClientImpl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
-
-
+    
     /**
      * The Aggregate Trade Streams push trade information that is aggregated for a single taker order.
      * <br><br>
@@ -52,8 +52,22 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int aggTradeStream(String symbol, WebSocketCallback callback) {
+        return aggTradeStream(symbol, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #aggTradeStream(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param symbol
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int aggTradeStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@aggTrade", baseUrl, symbol));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -70,8 +84,22 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int tradeStream(String symbol, WebSocketCallback callback) {
+        return tradeStream(symbol, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #tradeStream(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param symbol
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int tradeStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@trade", baseUrl, symbol));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -88,8 +116,23 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int klineStream(String symbol, String interval, WebSocketCallback callback) {
+        return klineStream(symbol, interval, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #klineStream(String, String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param symbol
+     * @param interval
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int klineStream(String symbol, String interval, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@kline_%s", baseUrl, symbol, interval));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -107,8 +150,22 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int miniTickerStream(String symbol, WebSocketCallback callback) {
+        return miniTickerStream(symbol, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #miniTickerStream(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param symbol
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int miniTickerStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@miniTicker", baseUrl, symbol));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -125,8 +182,21 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int allMiniTickerStream(WebSocketCallback callback) {
+        return allMiniTickerStream(noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #allMiniTickerStream(WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int allMiniTickerStream(WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/!miniTicker@arr", baseUrl));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -144,8 +214,22 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int symbolTicker(String symbol, WebSocketCallback callback) {
+        return symbolTicker(symbol, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #symbolTicker(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param symbol
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int symbolTicker(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@ticker", baseUrl, symbol));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -162,8 +246,21 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int allTickerStream(WebSocketCallback callback) {
+        return allTickerStream(noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #allTickerStream(WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int allTickerStream(WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/!ticker@arr", baseUrl));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -180,8 +277,22 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int bookTicker(String symbol, WebSocketCallback callback) {
+        return bookTicker(symbol, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #bookTicker(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param symbol
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int bookTicker(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@bookTicker", baseUrl, symbol));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -196,8 +307,21 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int allBookTickerStream(WebSocketCallback callback) {
+        return allBookTickerStream(noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #allBookTickerStream(WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int allBookTickerStream(WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/!bookTicker", baseUrl));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -218,8 +342,24 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int partialDepthStream(String symbol, int levels, int speed, WebSocketCallback callback) {
+        return partialDepthStream(symbol, levels, speed, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #partialDepthStream(String, int, int, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param symbol
+     * @param levels
+     * @param speed
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int partialDepthStream(String symbol, int levels, int speed, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@depth%s@%sms", baseUrl, symbol, levels, speed));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -238,8 +378,23 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int diffDepthStream(String symbol, int speed, WebSocketCallback callback) {
+        return diffDepthStream(symbol, speed, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #diffDepthStream(String, int, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param symbol
+     * @param speed
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int diffDepthStream(String symbol, int speed, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@depth@%sms", baseUrl, symbol, speed));
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -254,7 +409,22 @@ public class WebsocketClientImpl implements WebsocketClient {
     @Override
     public int listenUserStream(String listenKey, WebSocketCallback callback) {
         Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s", baseUrl, listenKey));
-        return createConnection(callback, request);
+        return listenUserStream(listenKey, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #listenUserStream(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     * @param listenKey
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */
+    @Override
+    public int listenUserStream(String listenKey, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s", baseUrl, listenKey));
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -266,9 +436,23 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int combineStreams(ArrayList<String> streams, WebSocketCallback callback) {
+        return combineStreams(streams, noopCallback, callback, noopCallback, noopCallback);
+    }
+
+    /**
+     * Same as {@link #combineStreams(ArrayList, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+      * @param streams
+     * @param onOpenCallback
+     * @param onMessageCallback
+     * @param onClosingCallback
+     * @param onFailureCallback
+     * @return
+     */    
+    @Override
+    public int combineStreams(ArrayList<String> streams, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         String url = UrlBuilder.buildStreamUrl(String.format("%s/stream", baseUrl), streams);
         Request request = RequestBuilder.buildWebsocketRequest(url);
-        return createConnection(callback, request);
+        return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
     /**
@@ -307,8 +491,15 @@ public class WebsocketClientImpl implements WebsocketClient {
         }
     }
 
-    private int createConnection(WebSocketCallback callback, Request request) {
-        WebSocketConnection connection = new WebSocketConnection(callback, request);
+    private int createConnection
+            (
+                    WebSocketCallback onOpenCallback,
+                    WebSocketCallback onMessageCallback,
+                    WebSocketCallback onClosingCallback,
+                    WebSocketCallback onFailureCallback,
+                    Request request
+            ) {
+        WebSocketConnection connection = new WebSocketConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
         connection.connect();
         int connectionId = connection.getConnectionId();
         connections.put(connectionId, connection);

--- a/src/main/java/com/binance/connector/client/impl/WebsocketClientImpl.java
+++ b/src/main/java/com/binance/connector/client/impl/WebsocketClientImpl.java
@@ -7,10 +7,12 @@ import com.binance.connector.client.utils.RequestBuilder;
 import com.binance.connector.client.utils.UrlBuilder;
 import com.binance.connector.client.utils.WebSocketCallback;
 import com.binance.connector.client.utils.WebSocketConnection;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+
 import okhttp3.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +29,8 @@ import org.slf4j.LoggerFactory;
 public class WebsocketClientImpl implements WebsocketClient {
     private final String baseUrl;
     private final Map<Integer, WebSocketConnection> connections = new HashMap<>();
-    private final WebSocketCallback noopCallback = msg -> {};
+    private final WebSocketCallback noopCallback = msg -> {
+    };
     private static final Logger logger = LoggerFactory.getLogger(WebsocketClientImpl.class);
 
     public WebsocketClientImpl() {
@@ -37,18 +40,18 @@ public class WebsocketClientImpl implements WebsocketClient {
     public WebsocketClientImpl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
-    
+
     /**
      * The Aggregate Trade Streams push trade information that is aggregated for a single taker order.
      * <br><br>
      * &lt;symbol&gt;@aggTrade
      * <br><br>
      * Update Speed: Real-time
-     * @param
-     * symbol Name of trading pair
+     *
+     * @param symbol Name of trading pair
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#aggregate-trade-streams">
-     *     https://binance-docs.github.io/apidocs/spot/en/#aggregate-trade-streams</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#aggregate-trade-streams</a>
      */
     @Override
     public int aggTradeStream(String symbol, WebSocketCallback callback) {
@@ -57,6 +60,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #aggTradeStream(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param symbol
      * @param onOpenCallback
      * @param onMessageCallback
@@ -76,11 +80,11 @@ public class WebsocketClientImpl implements WebsocketClient {
      * &lt;symbol&gt;@trade
      * <br><br>
      * Update Speed: Real-time
-     * @param
-     * symbol Name of trading pair
+     *
+     * @param symbol Name of trading pair
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#trade-streams">
-     *     https://binance-docs.github.io/apidocs/spot/en/#trade-streams</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#trade-streams</a>
      */
     @Override
     public int tradeStream(String symbol, WebSocketCallback callback) {
@@ -89,6 +93,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #tradeStream(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param symbol
      * @param onOpenCallback
      * @param onMessageCallback
@@ -108,11 +113,11 @@ public class WebsocketClientImpl implements WebsocketClient {
      * &lt;symbol&gt;@kline_&lt;interval&gt;
      * <br><br>
      * Update Speed: Real-time
-     * @param
-     * symbol Name of trading pair
+     *
+     * @param symbol Name of trading pair
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams">
-     *     https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams</a>
      */
     @Override
     public int klineStream(String symbol, String interval, WebSocketCallback callback) {
@@ -121,6 +126,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #klineStream(String, String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param symbol
      * @param interval
      * @param onOpenCallback
@@ -142,11 +148,11 @@ public class WebsocketClientImpl implements WebsocketClient {
      * &lt;symbol&gt;@miniTicker
      * <br><br>
      * Update Speed: Real-time
-     * @param
-     * symbol Name of trading pair
+     *
+     * @param symbol Name of trading pair
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-mini-ticker-stream">
-     *     https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-mini-ticker-stream</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-mini-ticker-stream</a>
      */
     @Override
     public int miniTickerStream(String symbol, WebSocketCallback callback) {
@@ -155,6 +161,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #miniTickerStream(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param symbol
      * @param onOpenCallback
      * @param onMessageCallback
@@ -176,9 +183,10 @@ public class WebsocketClientImpl implements WebsocketClient {
      * !miniTicker@arr
      * <br><br>
      * Update Speed: Real-time
+     *
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#all-market-mini-tickers-stream">
-     *     https://binance-docs.github.io/apidocs/spot/en/#all-market-mini-tickers-stream</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#all-market-mini-tickers-stream</a>
      */
     @Override
     public int allMiniTickerStream(WebSocketCallback callback) {
@@ -187,6 +195,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #allMiniTickerStream(WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param onOpenCallback
      * @param onMessageCallback
      * @param onClosingCallback
@@ -206,11 +215,11 @@ public class WebsocketClientImpl implements WebsocketClient {
      * &lt;symbol&gt;@ticker
      * <br><br>
      * Update Speed: Real-time
-     * @param
-     * symbol Name of trading pair
+     *
+     * @param symbol Name of trading pair
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-ticker-streams">
-     *     https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-ticker-streams</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-ticker-streams</a>
      */
     @Override
     public int symbolTicker(String symbol, WebSocketCallback callback) {
@@ -219,6 +228,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #symbolTicker(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param symbol
      * @param onOpenCallback
      * @param onMessageCallback
@@ -240,9 +250,10 @@ public class WebsocketClientImpl implements WebsocketClient {
      * !ticker@arr
      * <br><br>
      * Update Speed: Real-time
+     *
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#all-market-tickers-stream">
-     *     https://binance-docs.github.io/apidocs/spot/en/#all-market-tickers-stream</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#all-market-tickers-stream</a>
      */
     @Override
     public int allTickerStream(WebSocketCallback callback) {
@@ -251,6 +262,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #allTickerStream(WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param onOpenCallback
      * @param onMessageCallback
      * @param onClosingCallback
@@ -269,11 +281,11 @@ public class WebsocketClientImpl implements WebsocketClient {
      * &lt;symbol&gt;@bookTicker
      * <br><br>
      * Update Speed: Real-time
-     * @param
-     * symbol Name of trading pair
+     *
+     * @param symbol Name of trading pair
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-book-ticker-streams">
-     *     https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-book-ticker-streams</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-book-ticker-streams</a>
      */
     @Override
     public int bookTicker(String symbol, WebSocketCallback callback) {
@@ -282,6 +294,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #bookTicker(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param symbol
      * @param onOpenCallback
      * @param onMessageCallback
@@ -301,9 +314,10 @@ public class WebsocketClientImpl implements WebsocketClient {
      * !bookTicker
      * <br><br>
      * Update Speed: Real-time
+     *
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#all-book-tickers-stream">
-     *     https://binance-docs.github.io/apidocs/spot/en/#all-book-tickers-stream</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#all-book-tickers-stream</a>
      */
     @Override
     public int allBookTickerStream(WebSocketCallback callback) {
@@ -312,6 +326,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #allBookTickerStream(WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param onOpenCallback
      * @param onMessageCallback
      * @param onClosingCallback
@@ -330,15 +345,13 @@ public class WebsocketClientImpl implements WebsocketClient {
      * &lt;symbol&gt;@depth&lt;levels&gt;@&lt;speed&gt;ms
      * <br><br>
      * Update Speed: 1000ms or 100ms
-     * @param
-     * symbol Name of trading pair
-     * @param
-     * levels Valid are 5, 10, or 20
-     * @param
-     * speed 1000ms or 100ms
+     *
+     * @param symbol Name of trading pair
+     * @param levels Valid are 5, 10, or 20
+     * @param speed  1000ms or 100ms
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#partial-book-depth-streams">
-     *     https://binance-docs.github.io/apidocs/spot/en/#partial-book-depth-streams</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#partial-book-depth-streams</a>
      */
     @Override
     public int partialDepthStream(String symbol, int levels, int speed, WebSocketCallback callback) {
@@ -347,6 +360,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #partialDepthStream(String, int, int, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param symbol
      * @param levels
      * @param speed
@@ -368,13 +382,12 @@ public class WebsocketClientImpl implements WebsocketClient {
      * &lt;symbol&gt;@depth@&lt;speed&gt;ms
      * <br><br>
      * Update Speed: 1000ms or 100ms
-     * @param
-     * symbol Name of trading pair
-     * @param
-     * speed 1000ms or 100ms
+     *
+     * @param symbol Name of trading pair
+     * @param speed  1000ms or 100ms
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#diff-depth-stream">
-     *     https://binance-docs.github.io/apidocs/spot/en/#diff-depth-stream</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#diff-depth-stream</a>
      */
     @Override
     public int diffDepthStream(String symbol, int speed, WebSocketCallback callback) {
@@ -383,6 +396,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #diffDepthStream(String, int, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param symbol
      * @param speed
      * @param onOpenCallback
@@ -399,12 +413,12 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * User Data Streams are accessed at /ws/&lt;listenKey&gt;
-     * @param
-     * listenKey listen key obtained from this
-     *           <a href="https://binance-docs.github.io/apidocs/spot/en/#listen-key-spot">endpoint</a>
+     *
+     * @param listenKey listen key obtained from this
+     *                  <a href="https://binance-docs.github.io/apidocs/spot/en/#listen-key-spot">endpoint</a>
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#user-data-streams">
-     *     https://binance-docs.github.io/apidocs/spot/en/#user-data-streams</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#user-data-streams</a>
      */
     @Override
     public int listenUserStream(String listenKey, WebSocketCallback callback) {
@@ -414,6 +428,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #listenUserStream(String, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
+     *
      * @param listenKey
      * @param onOpenCallback
      * @param onMessageCallback
@@ -429,10 +444,11 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Combined streams are accessed at /stream?streams=&lt;streamName1&gt;/&lt;streamName2&gt;/&lt;streamName3&gt;
+     *
      * @param streams A list of stream names to be combined <br>
      * @return int - Connection ID
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#websocket-market-streams">
-     *     https://binance-docs.github.io/apidocs/spot/en/#websocket-market-streams</a>
+     * https://binance-docs.github.io/apidocs/spot/en/#websocket-market-streams</a>
      */
     @Override
     public int combineStreams(ArrayList<String> streams, WebSocketCallback callback) {
@@ -441,13 +457,14 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Same as {@link #combineStreams(ArrayList, WebSocketCallback)} plus accepts callbacks for all major websocket connection events.
-      * @param streams
+     *
+     * @param streams
      * @param onOpenCallback
      * @param onMessageCallback
      * @param onClosingCallback
      * @param onFailureCallback
      * @return
-     */    
+     */
     @Override
     public int combineStreams(ArrayList<String> streams, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
         String url = UrlBuilder.buildStreamUrl(String.format("%s/stream", baseUrl), streams);
@@ -457,6 +474,7 @@ public class WebsocketClientImpl implements WebsocketClient {
 
     /**
      * Closes a specific stream based on stream Id.
+     *
      * @param connectionId
      */
     @Override
@@ -491,14 +509,13 @@ public class WebsocketClientImpl implements WebsocketClient {
         }
     }
 
-    private int createConnection
-            (
-                    WebSocketCallback onOpenCallback,
-                    WebSocketCallback onMessageCallback,
-                    WebSocketCallback onClosingCallback,
-                    WebSocketCallback onFailureCallback,
-                    Request request
-            ) {
+    private int createConnection(
+            WebSocketCallback onOpenCallback,
+            WebSocketCallback onMessageCallback,
+            WebSocketCallback onClosingCallback,
+            WebSocketCallback onFailureCallback,
+            Request request
+    ) {
         WebSocketConnection connection = new WebSocketConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
         connection.connect();
         int connectionId = connection.getConnectionId();

--- a/src/main/java/com/binance/connector/client/utils/WebSocketConnection.java
+++ b/src/main/java/com/binance/connector/client/utils/WebSocketConnection.java
@@ -1,13 +1,10 @@
 package com.binance.connector.client.utils;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.WebSocket;
-import okhttp3.WebSocketListener;
+import okhttp3.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class WebSocketConnection extends WebSocketListener {
     private static final AtomicInteger connectionCounter = new AtomicInteger(0);
@@ -15,7 +12,7 @@ public class WebSocketConnection extends WebSocketListener {
     private static final OkHttpClient client = HttpClientSingleton.getHttpClient();
     private static final Logger logger = LoggerFactory.getLogger(WebSocketConnection.class);
 
-    private final WebSocketCallback callback;
+    private final WebSocketCallback onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback;
     private final int connectionId;
     private final Request request;
     private final String streamName;
@@ -24,8 +21,18 @@ public class WebSocketConnection extends WebSocketListener {
 
     private final Object mutex;
 
-    public WebSocketConnection(WebSocketCallback callback, Request request) {
-        this.callback = callback;
+    public WebSocketConnection
+            (
+                    WebSocketCallback onOpenCallback,
+                    WebSocketCallback onMessageCallback,
+                    WebSocketCallback onClosingCallback,
+                    WebSocketCallback onFailureCallback,
+                    Request request
+            ) {
+        this.onOpenCallback = onOpenCallback;
+        this.onMessageCallback = onMessageCallback;
+        this.onClosingCallback = onClosingCallback;
+        this.onFailureCallback = onFailureCallback;
         this.connectionId = WebSocketConnection.connectionCounter.incrementAndGet();
         this.request = request;
         this.streamName = request.url().host() + request.url().encodedPath();
@@ -59,15 +66,23 @@ public class WebSocketConnection extends WebSocketListener {
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         logger.info("[Connection {}] Connected to Server", connectionId);
+        onOpenCallback.onReceive(null);
+    }
+
+    @Override
+    public void onClosing(WebSocket webSocket, int code, String reason) {
+        super.onClosing(webSocket, code, reason);
+        onClosingCallback.onReceive(reason);
     }
 
     @Override
     public void onMessage(WebSocket webSocket, String text) {
-        callback.onReceive(text);
+        onMessageCallback.onReceive(text);
     }
 
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
         logger.error("[Connection {}] Failure", connectionId, t);
+        onFailureCallback.onReceive(null);
     }
 }

--- a/src/main/java/com/binance/connector/client/utils/WebSocketConnection.java
+++ b/src/main/java/com/binance/connector/client/utils/WebSocketConnection.java
@@ -21,14 +21,13 @@ public class WebSocketConnection extends WebSocketListener {
 
     private final Object mutex;
 
-    public WebSocketConnection
-            (
-                    WebSocketCallback onOpenCallback,
-                    WebSocketCallback onMessageCallback,
-                    WebSocketCallback onClosingCallback,
-                    WebSocketCallback onFailureCallback,
-                    Request request
-            ) {
+    public WebSocketConnection(
+            WebSocketCallback onOpenCallback,
+            WebSocketCallback onMessageCallback,
+            WebSocketCallback onClosingCallback,
+            WebSocketCallback onFailureCallback,
+            Request request
+    ) {
         this.onOpenCallback = onOpenCallback;
         this.onMessageCallback = onMessageCallback;
         this.onClosingCallback = onClosingCallback;

--- a/src/test/java/examples/websocket/TradeStreamWithAllCallbacks.java
+++ b/src/test/java/examples/websocket/TradeStreamWithAllCallbacks.java
@@ -1,0 +1,45 @@
+package examples.websocket;
+
+import com.binance.connector.client.impl.WebsocketClientImpl;
+import com.binance.connector.client.utils.WebSocketCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TradeStreamWithAllCallbacks {
+
+    private static final Logger logger = LoggerFactory.getLogger(TradeStreamWithAllCallbacks.class);
+
+    private static volatile boolean isTradeStreamUp = false;
+    private static WebSocketCallback onOpenCallback;
+    private static WebSocketCallback onMessageCallback;
+    private static WebSocketCallback onClosingCallback;
+    private static WebSocketCallback onFailureCallback;
+
+    public static void main(String[] args) {
+        WebsocketClientImpl client = new WebsocketClientImpl();
+        onOpenCallback = openEvent -> {
+            isTradeStreamUp = true;
+        };
+        onMessageCallback = (message) -> {
+            System.out.println(message);
+        };
+        onClosingCallback = closingEvent -> {
+            isTradeStreamUp = false;
+            connectToTradeStream(client, onOpenCallback, onMessageCallback, onClosingCallback, onClosingCallback);
+        };
+        onFailureCallback = failureEvent -> {
+            isTradeStreamUp = false;
+            connectToTradeStream(client, onOpenCallback, onMessageCallback, onClosingCallback, onClosingCallback);
+        };
+        connectToTradeStream(client, onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback);
+    }
+
+    private static void connectToTradeStream(
+            WebsocketClientImpl client,
+            WebSocketCallback onOpenCallback,
+            WebSocketCallback onMessageCallback,
+            WebSocketCallback onClosingCallback,
+            WebSocketCallback onFailureCallback) {
+        client.tradeStream("btcusdt", onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback);
+    }
+}


### PR DESCRIPTION
I've been concerned about not being able to detect when the Websocket connection is lost with the current version of the connector.

I've been too much concerned that I've chosen to rely on API to get balance and orders statuses instead of relying on Websocket. Until now!

Yesterday I've found to time to add the possibility to attach callbacks for ws connection closure and failure events. 
Did it first on my side on copy classes of yours in my project .

Today, I've re-implemented the same thing on a fork of your repo.

So please find in this PR a proposal that adresses this lack of the connector.