### PR TITLE
v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.5.0 - 2022-05-13
+
+### Added
+- GET /sapi/v1/margin/rateLimit/order added The endpoint will display the user's current margin order count usage for all intervals.
+- GET /sapi/v1/portfolio/account to support query portfolio margin account info
+- Information on Trailing Stops (Documentation)
+
+### Changed
+- Websocket symbol will be converted to lower case regardless of user input
+
 ## 1.4.0 - 2022-04-06
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.binance</groupId>
     <artifactId>binance-connector-java</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>lightweight connector to API</description>

--- a/src/main/java/com/binance/connector/client/SpotClient.java
+++ b/src/main/java/com/binance/connector/client/SpotClient.java
@@ -13,6 +13,7 @@ import com.binance.connector.client.impl.spot.Market;
 import com.binance.connector.client.impl.spot.Mining;
 import com.binance.connector.client.impl.spot.NFT;
 import com.binance.connector.client.impl.spot.Pay;
+import com.binance.connector.client.impl.spot.PortfolioMargin;
 import com.binance.connector.client.impl.spot.Rebate;
 import com.binance.connector.client.impl.spot.Savings;
 import com.binance.connector.client.impl.spot.SubAccount;
@@ -35,6 +36,7 @@ public interface SpotClient {
     Mining createMining();
     NFT createNFT();
     Pay createPay();
+    PortfolioMargin createPortfolioMargin();
     Rebate createRebate();
     Savings createSavings();
     SubAccount createSubAccount();

--- a/src/main/java/com/binance/connector/client/impl/SpotClientImpl.java
+++ b/src/main/java/com/binance/connector/client/impl/SpotClientImpl.java
@@ -15,6 +15,7 @@ import com.binance.connector.client.impl.spot.Market;
 import com.binance.connector.client.impl.spot.Mining;
 import com.binance.connector.client.impl.spot.NFT;
 import com.binance.connector.client.impl.spot.Pay;
+import com.binance.connector.client.impl.spot.PortfolioMargin;
 import com.binance.connector.client.impl.spot.Rebate;
 import com.binance.connector.client.impl.spot.Savings;
 import com.binance.connector.client.impl.spot.SubAccount;
@@ -123,6 +124,11 @@ public class SpotClientImpl implements SpotClient {
     @Override
     public Pay createPay() {
         return new Pay(baseUrl, apiKey, secretKey, showLimitUsage);
+    }
+
+    @Override
+    public PortfolioMargin createPortfolioMargin() {
+        return new PortfolioMargin(baseUrl, apiKey, secretKey, showLimitUsage);
     }
 
     @Override

--- a/src/main/java/com/binance/connector/client/impl/WebsocketClientImpl.java
+++ b/src/main/java/com/binance/connector/client/impl/WebsocketClientImpl.java
@@ -7,6 +7,7 @@ import com.binance.connector.client.utils.RequestBuilder;
 import com.binance.connector.client.utils.UrlBuilder;
 import com.binance.connector.client.utils.WebSocketCallback;
 import com.binance.connector.client.utils.WebSocketConnection;
+import com.binance.connector.client.utils.ParameterChecker;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -55,7 +56,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int aggTradeStream(String symbol, WebSocketCallback callback) {
-        return aggTradeStream(symbol, noopCallback, callback, noopCallback, noopCallback);
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        return aggTradeStream(symbol.toLowerCase(), noopCallback, callback, noopCallback, noopCallback);
     }
 
     /**
@@ -70,7 +72,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int aggTradeStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
-        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@aggTrade", baseUrl, symbol));
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@aggTrade", baseUrl, symbol.toLowerCase()));
         return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
@@ -88,7 +91,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int tradeStream(String symbol, WebSocketCallback callback) {
-        return tradeStream(symbol, noopCallback, callback, noopCallback, noopCallback);
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        return tradeStream(symbol.toLowerCase(), noopCallback, callback, noopCallback, noopCallback);
     }
 
     /**
@@ -103,7 +107,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int tradeStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
-        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@trade", baseUrl, symbol));
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@trade", baseUrl, symbol.toLowerCase()));
         return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
@@ -121,7 +126,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int klineStream(String symbol, String interval, WebSocketCallback callback) {
-        return klineStream(symbol, interval, noopCallback, callback, noopCallback, noopCallback);
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        return klineStream(symbol.toLowerCase(), interval, noopCallback, callback, noopCallback, noopCallback);
     }
 
     /**
@@ -137,7 +143,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int klineStream(String symbol, String interval, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
-        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@kline_%s", baseUrl, symbol, interval));
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@kline_%s", baseUrl, symbol.toLowerCase(), interval));
         return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
@@ -156,7 +163,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int miniTickerStream(String symbol, WebSocketCallback callback) {
-        return miniTickerStream(symbol, noopCallback, callback, noopCallback, noopCallback);
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        return miniTickerStream(symbol.toLowerCase(), noopCallback, callback, noopCallback, noopCallback);
     }
 
     /**
@@ -171,7 +179,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int miniTickerStream(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
-        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@miniTicker", baseUrl, symbol));
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@miniTicker", baseUrl, symbol.toLowerCase()));
         return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
@@ -223,7 +232,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int symbolTicker(String symbol, WebSocketCallback callback) {
-        return symbolTicker(symbol, noopCallback, callback, noopCallback, noopCallback);
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        return symbolTicker(symbol.toLowerCase(), noopCallback, callback, noopCallback, noopCallback);
     }
 
     /**
@@ -238,7 +248,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int symbolTicker(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
-        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@ticker", baseUrl, symbol));
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@ticker", baseUrl, symbol.toLowerCase()));
         return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
@@ -289,7 +300,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int bookTicker(String symbol, WebSocketCallback callback) {
-        return bookTicker(symbol, noopCallback, callback, noopCallback, noopCallback);
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        return bookTicker(symbol.toLowerCase(), noopCallback, callback, noopCallback, noopCallback);
     }
 
     /**
@@ -304,7 +316,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int bookTicker(String symbol, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
-        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@bookTicker", baseUrl, symbol));
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@bookTicker", baseUrl, symbol.toLowerCase()));
         return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
@@ -355,7 +368,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int partialDepthStream(String symbol, int levels, int speed, WebSocketCallback callback) {
-        return partialDepthStream(symbol, levels, speed, noopCallback, callback, noopCallback, noopCallback);
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        return partialDepthStream(symbol.toLowerCase(), levels, speed, noopCallback, callback, noopCallback, noopCallback);
     }
 
     /**
@@ -372,7 +386,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int partialDepthStream(String symbol, int levels, int speed, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
-        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@depth%s@%sms", baseUrl, symbol, levels, speed));
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@depth%s@%sms", baseUrl, symbol.toLowerCase(), levels, speed));
         return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 
@@ -391,7 +406,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int diffDepthStream(String symbol, int speed, WebSocketCallback callback) {
-        return diffDepthStream(symbol, speed, noopCallback, callback, noopCallback, noopCallback);
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        return diffDepthStream(symbol.toLowerCase(), speed, noopCallback, callback, noopCallback, noopCallback);
     }
 
     /**
@@ -407,7 +423,8 @@ public class WebsocketClientImpl implements WebsocketClient {
      */
     @Override
     public int diffDepthStream(String symbol, int speed, WebSocketCallback onOpenCallback, WebSocketCallback onMessageCallback, WebSocketCallback onClosingCallback, WebSocketCallback onFailureCallback) {
-        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@depth@%sms", baseUrl, symbol, speed));
+        ParameterChecker.checkParameterType(symbol, String.class, "symbol");
+        Request request = RequestBuilder.buildWebsocketRequest(String.format("%s/ws/%s@depth@%sms", baseUrl, symbol.toLowerCase(), speed));
         return createConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
     }
 

--- a/src/main/java/com/binance/connector/client/impl/spot/Margin.java
+++ b/src/main/java/com/binance/connector/client/impl/spot/Margin.java
@@ -937,4 +937,25 @@ public class Margin {
         ParameterChecker.checkParameter(parameters, "symbol", String.class);
         return requestHandler.sendSignedRequest(baseUrl, ISOLATED_MARGIN_TIER, parameters, HttpMethod.GET, showLimitUsage);
     }
+
+    private final String ORDER_RATE_LIMIT = "/sapi/v1/margin/rateLimit/order";
+    /**
+     * Displays the user's current margin order count usage for all intervals.
+     * <br><br>
+     * GET /sapi/v1/margin/rateLimit/order
+     * <br>
+     * @param
+     * parameters LinkedHashedMap of String,Object pair
+     *            where String is the name of the parameter and Object is the value of the parameter
+     * <br><br>
+     * isIsolated -- optional/string -- for isolated margin or not, "TRUE", "FALSE"，default "FALSE" <br>
+     * symbol -- optional/string -- isolated symbol, mandatory for isolated margin <br>
+     * recvWindow -- optional/long -- The value cannot be greater than 60000 <br>
+     * @return String
+     * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#query-current-margin-order-count-usage-trade">
+     *     https://binance-docs.github.io/apidocs/spot/en/#query-current-margin-order-count-usage-trade</a>
+     */
+    public String orderRateLimit(LinkedHashMap<String,Object> parameters) {
+        return requestHandler.sendSignedRequest(baseUrl, ORDER_RATE_LIMIT, parameters, HttpMethod.GET, showLimitUsage);
+    }
 }

--- a/src/main/java/com/binance/connector/client/impl/spot/PortfolioMargin.java
+++ b/src/main/java/com/binance/connector/client/impl/spot/PortfolioMargin.java
@@ -1,0 +1,44 @@
+package com.binance.connector.client.impl.spot;
+
+import com.binance.connector.client.enums.HttpMethod;
+import com.binance.connector.client.utils.ParameterChecker;
+import com.binance.connector.client.utils.RequestHandler;
+
+import java.util.LinkedHashMap;
+
+public class PortfolioMargin {
+    /**
+     * <h2>Portfolio Margin Endpoints</h2>
+     * All endpoints under the
+     * <a href="https://binance-docs.github.io/apidocs/spot/en/#portfolio-margin-endpoints">PortfolioMargin Endpoint</a>
+     * section of the API documentation will be implemented in this class.
+     * <br>
+     * Response will be returned in <i>String format</i>.
+     */
+    private final String baseUrl;
+    private final RequestHandler requestHandler;
+    private final boolean showLimitUsage;
+
+    public PortfolioMargin(String baseUrl, String apiKey, String secretKey, boolean showLimitUsage) {
+        this.baseUrl = baseUrl;
+        this.requestHandler = new RequestHandler(apiKey, secretKey);
+        this.showLimitUsage = showLimitUsage;
+    }
+
+    private final String ACCOUNT = "/sapi/v1/portfolio/account";
+    /**
+     * GET /sapi/v1/portfolio/account
+     * <br>
+     * @param
+     * parameters LinkedHashedMap of String,Object pair
+     *            where String is the name of the parameter and Object is the value of the parameter
+     * <br><br>
+     * recvWindow -- optional/long <br>
+     * @return String
+     * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#get-portfolio-margin-account-info-user_data">
+     *     https://binance-docs.github.io/apidocs/spot/en/#get-portfolio-margin-account-info-user_data</a>
+     */
+    public String getAccount(LinkedHashMap<String,Object> parameters) {
+        return requestHandler.sendSignedRequest(baseUrl, ACCOUNT, parameters, HttpMethod.GET, showLimitUsage);
+    }
+}

--- a/src/main/java/com/binance/connector/client/impl/spot/Trade.java
+++ b/src/main/java/com/binance/connector/client/impl/spot/Trade.java
@@ -45,6 +45,7 @@ public class Trade {
      * newClientOrderId -- optional/string <br>
      * stopPrice -- optional/decimal <br>
      * icebergQty -- optional/deciaml <br>
+     * trailingDelta -- optional/long <br>
      * newOrderRespType -- optional/enum <br>
      * recvWindow -- optional/long <br>
      * @return String
@@ -78,6 +79,7 @@ public class Trade {
      * newClientOrderId -- optional/string <br>
      * stopPrice -- optional/decimal <br>
      * icebergQty -- optional/deciaml <br>
+     * trailingDelta -- optional/long <br>
      * newOrderRespType -- optional/enum <br>
      * recvWindow -- optional/long <br>
      * @return String
@@ -219,6 +221,7 @@ public class Trade {
      * limitClientOrderId -- optional/string <br>
      * price -- mandatory/decimal <br>
      * limitIcebergQty -- optional/decimal <br>
+     * trailingDelta -- optional/long <br>
      * stopClientOrderId -- optional/string <br>
      * stopPrice -- mandatory/decimal <br>
      * stopLimitPrice -- optional/decimal <br>

--- a/src/main/java/com/binance/connector/client/utils/ParameterChecker.java
+++ b/src/main/java/com/binance/connector/client/utils/ParameterChecker.java
@@ -9,22 +9,21 @@ public class ParameterChecker {
     }
 
     public static void checkParameter(LinkedHashMap<String,Object> parameters, String parameter, Class t) {
-        if (checkRequiredParameter(parameters, parameter)) {
-            checkParameterType(parameters.get(parameter), t, parameter);
-        }
+        checkRequiredParameter(parameters, parameter);
+        checkParameterType(parameters.get(parameter), t, parameter);
     }
 
-    public static boolean checkRequiredParameter(LinkedHashMap<String,Object> parameters, String parameter) {
+    public static void checkRequiredParameter(LinkedHashMap<String,Object> parameters, String parameter) {
         if (!parameters.containsKey(parameter)) {
             throw new BinanceConnectorException(String.format("\"%s\" is a mandatory parameter!", parameter));
         }
-        return true;
     }
 
-    public static boolean checkParameterType(Object parameter, Class t, String name) {
+    public static void checkParameterType(Object parameter, Class t, String name) {
         if (!t.isInstance(parameter)) {
             throw new BinanceConnectorException(String.format("\"%s\" must be of %s type.", name, t));
+        } else if (t == String.class && parameter.toString().trim().equals("")) {
+            throw new BinanceConnectorException(String.format("\"%s\" must not be empty.", name));
         }
-        return true;
     }
 }

--- a/src/test/java/examples/margin/OrderRateLimit.java
+++ b/src/test/java/examples/margin/OrderRateLimit.java
@@ -1,0 +1,19 @@
+package examples.margin;
+
+import com.binance.connector.client.impl.SpotClientImpl;
+import examples.PrivateConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+
+public class OrderRateLimit {
+    private static final Logger logger = LoggerFactory.getLogger(OrderRateLimit.class);
+    public static void main(String[] args) {
+        LinkedHashMap<String,Object> parameters = new LinkedHashMap<>();
+
+        SpotClientImpl client = new SpotClientImpl(PrivateConfig.API_KEY, PrivateConfig.SECRET_KEY);
+        String result = client.createMargin().orderRateLimit(parameters);
+        logger.info(result);
+    }
+}

--- a/src/test/java/examples/portfoliomargin/GetAccount.java
+++ b/src/test/java/examples/portfoliomargin/GetAccount.java
@@ -1,0 +1,18 @@
+package examples.portfoliomargin;
+
+import com.binance.connector.client.impl.SpotClientImpl;
+import examples.PrivateConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.LinkedHashMap;
+
+public class GetAccount {
+    private static final Logger logger = LoggerFactory.getLogger(GetAccount.class);
+    public static void main(String[] args) {
+        LinkedHashMap<String,Object> parameters = new LinkedHashMap<>();
+
+        SpotClientImpl client = new SpotClientImpl(PrivateConfig.API_KEY, PrivateConfig.SECRET_KEY);
+        String result = client.createPortfolioMargin().getAccount(parameters);
+        logger.info(result);
+    }
+}

--- a/src/test/java/unit/TestParameterChecker.java
+++ b/src/test/java/unit/TestParameterChecker.java
@@ -11,6 +11,8 @@ public class TestParameterChecker {
         put("key1","value1");
         put("key2",2);
     }};
+    private final String mockObject = "mockObject";
+    private final String emptyString = "";
 
     @Test
     public void testcheckParameter() {
@@ -20,12 +22,22 @@ public class TestParameterChecker {
 
     @Test(expected = BinanceConnectorException.class)
     public void testcheckParameterNoKey() {
-        ParameterChecker.checkParameter(mockParameters, "InvalidKey", String.class);
+        ParameterChecker.checkRequiredParameter(mockParameters, "InvalidKey");
     }
 
     @Test(expected = BinanceConnectorException.class)
     public void testcheckParameterWrongType() {
-        ParameterChecker.checkParameter(mockParameters, "key1", Integer.class);
+        ParameterChecker.checkParameterType(mockObject, Integer.class, "mockObject");
+    }
+
+    @Test(expected = BinanceConnectorException.class)
+    public void testcheckEmptyString() {
+        ParameterChecker.checkParameterType(emptyString, String.class, "mockObject");
+    }
+
+    @Test(expected = BinanceConnectorException.class)
+    public void testcheckNull() {
+        ParameterChecker.checkParameterType(null, String.class, "mockObject");
     }
 
 }

--- a/src/test/java/unit/margin/TestOrderRateLimit.java
+++ b/src/test/java/unit/margin/TestOrderRateLimit.java
@@ -1,0 +1,46 @@
+package unit.margin;
+
+import com.binance.connector.client.enums.HttpMethod;
+import com.binance.connector.client.impl.SpotClientImpl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import unit.MockWebServerDispatcher;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestOrderRateLimit {
+    private MockWebServer mockWebServer;
+    private String baseUrl;
+    private final String prefix = "/";
+    private final String MOCK_RESPONSE = "{\"key_1\": \"value_1\", \"key_2\": \"value_2\"}";
+    private final String apiKey = "apiKey";
+    private final String secretKey = "secretKey";
+
+    @Before
+    public void init() {
+        this.mockWebServer = new MockWebServer();
+        this.baseUrl = mockWebServer.url(prefix).toString();
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testOrderRateLimit() {
+        String path = "/sapi/v1/margin/rateLimit/order";
+        LinkedHashMap<String,Object> parameters = new LinkedHashMap<>();
+
+        Dispatcher dispatcher = MockWebServerDispatcher.getDispatcher(prefix, path, MOCK_RESPONSE, HttpMethod.GET, 200);
+        mockWebServer.setDispatcher(dispatcher);
+
+        SpotClientImpl client = new SpotClientImpl(apiKey, secretKey, baseUrl);
+        String result = client.createMargin().orderRateLimit(parameters);
+        assertEquals(MOCK_RESPONSE, result);
+    }
+}

--- a/src/test/java/unit/portfoliomargin/TestGetAccount.java
+++ b/src/test/java/unit/portfoliomargin/TestGetAccount.java
@@ -1,0 +1,41 @@
+package unit.portfoliomargin;
+
+import com.binance.connector.client.enums.HttpMethod;
+import com.binance.connector.client.impl.SpotClientImpl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Test;
+import unit.MockWebServerDispatcher;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestGetAccount {
+    private MockWebServer mockWebServer;
+    private String baseUrl;
+    private final String prefix = "/";
+    private final String MOCK_RESPONSE = "{\"key_1\": \"value_1\", \"key_2\": \"value_2\"}";
+    private final String apiKey = "apiKey";
+    private final String secretKey = "secretKey";
+
+    @Before
+    public void init() {
+        this.mockWebServer = new MockWebServer();
+        this.baseUrl = mockWebServer.url(prefix).toString();
+    }
+
+    @Test
+    public void testGetAccount() {
+        String path = "/sapi/v1/portfolio/account";
+        LinkedHashMap<String,Object> parameters = new LinkedHashMap<>();
+
+        Dispatcher dispatcher = MockWebServerDispatcher.getDispatcher(prefix, path, MOCK_RESPONSE, HttpMethod.GET, 200);
+        mockWebServer.setDispatcher(dispatcher);
+
+        SpotClientImpl client = new SpotClientImpl(apiKey, secretKey, baseUrl);
+        String result = client.createPortfolioMargin().getAccount(parameters);
+        assertEquals(MOCK_RESPONSE, result);
+    }
+}


### PR DESCRIPTION
- GET /sapi/v1/margin/rateLimit/order added The endpoint will display the user's current margin order count usage for all intervals.
- GET /sapi/v1/portfolio/account to support query portfolio margin account info
- Information on Trailing Stops (Documentation)
- Websocket symbol will be converted to lower case regardless of user input