### PR TITLE
Remove requirement for the asset parameter for the Fixed and Activity Project position API call

### DIFF
--- a/src/main/java/com/binance/connector/client/impl/spot/Savings.java
+++ b/src/main/java/com/binance/connector/client/impl/spot/Savings.java
@@ -201,7 +201,7 @@ public class Savings {
      * parameters LinkedHashedMap of String,Object pair
      *            where String is the name of the parameter and Object is the value of the parameter
      * <br><br>
-     * asset -- mandatory/string <br>
+     * asset -- optional/string <br>
      * projectId -- optional/string <br>
      * status -- optional/enum -- "HOLDING", "REDEEMED" <br>
      * recvWindow -- optional/long <br>
@@ -209,8 +209,7 @@ public class Savings {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#get-fixed-activity-project-position-user_data">
      *     https://binance-docs.github.io/apidocs/spot/en/#get-fixed-activity-project-position-user_data</a>
      */
-    public String projectPostion(LinkedHashMap<String, Object> parameters) {
-        ParameterChecker.checkParameter(parameters, "asset", String.class);
+    public String projectPosition(LinkedHashMap<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, PROJECT_POSITION, parameters, HttpMethod.GET, showLimitUsage);
     }
 

--- a/src/test/java/examples/savings/ProjectPosition.java
+++ b/src/test/java/examples/savings/ProjectPosition.java
@@ -16,7 +16,7 @@ public final class ProjectPosition {
         parameters.put("asset", "USDT");
 
         SpotClientImpl client = new SpotClientImpl(PrivateConfig.API_KEY, PrivateConfig.SECRET_KEY);
-        String result = client.createSavings().projectPostion(parameters);
+        String result = client.createSavings().projectPosition(parameters);
         logger.info(result);
     }
 }

--- a/src/test/java/unit/savings/TestProjectPosition.java
+++ b/src/test/java/unit/savings/TestProjectPosition.java
@@ -34,7 +34,7 @@ public class TestProjectPosition {
         mockWebServer.setDispatcher(dispatcher);
 
         SpotClientImpl client = new SpotClientImpl(MockData.API_KEY, MockData.SECRET_KEY, baseUrl);
-        assertThrows(BinanceConnectorException.class, () -> client.createSavings().projectPostion(parameters));
+        assertThrows(BinanceConnectorException.class, () -> client.createSavings().projectPosition(parameters));
     }
 
     @Test
@@ -47,7 +47,7 @@ public class TestProjectPosition {
         mockWebServer.setDispatcher(dispatcher);
 
         SpotClientImpl client = new SpotClientImpl(MockData.API_KEY, MockData.SECRET_KEY, baseUrl);
-        String result = client.createSavings().projectPostion(parameters);
+        String result = client.createSavings().projectPosition(parameters);
         assertEquals(MockData.MOCK_RESPONSE, result);
     }
 }


### PR DESCRIPTION
The API call to the fixed and activity project position list does not require the asset parameter after the [API documentation]. This commit removes the required asset parameter and also uses the opportunity to fix the typo in the method name.

[API documentation]: https://binance-docs.github.io/apidocs/spot/en/#get-fixed-activity-project-position-user_data