### PR TITLE
Tuning OkHttpClient settings

### DIFF
--- a/src/main/java/com/binance/connector/client/utils/httpclient/HttpClientSingleton.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/HttpClientSingleton.java
@@ -12,12 +12,12 @@ public final class HttpClientSingleton {
 
     private static void createHttpClient(ProxyAuth proxy) {
         if (proxy == null) {
-            httpClient = new OkHttpClient();
+            httpClient = new OkHttpClient(OkHttpClientBuilder.builder);
         } else {
             if (proxy.getAuth() == null) {
-                httpClient = new OkHttpClient.Builder().proxy(proxy.getProxy()).build();
+                httpClient = OkHttpClientBuilder.builder.proxy(proxy.getProxy()).build();
             } else {
-                httpClient = new OkHttpClient.Builder().proxy(proxy.getProxy()).proxyAuthenticator(proxy.getAuth()).build();
+                httpClient = OkHttpClientBuilder.builder.proxy(proxy.getProxy()).proxyAuthenticator(proxy.getAuth()).build();
             }
         }
     }

--- a/src/main/java/com/binance/connector/client/utils/httpclient/HttpClientSingleton.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/HttpClientSingleton.java
@@ -12,12 +12,12 @@ public final class HttpClientSingleton {
 
     private static void createHttpClient(ProxyAuth proxy) {
         if (proxy == null) {
-            httpClient = new OkHttpClient(OkHttpClientBuilder.builder);
+            httpClient = new OkHttpClient(OkHttpClientBuilder.getBuilder());
         } else {
             if (proxy.getAuth() == null) {
-                httpClient = OkHttpClientBuilder.builder.proxy(proxy.getProxy()).build();
+                httpClient = OkHttpClientBuilder.getBuilder().proxy(proxy.getProxy()).build();
             } else {
-                httpClient = OkHttpClientBuilder.builder.proxy(proxy.getProxy()).proxyAuthenticator(proxy.getAuth()).build();
+                httpClient = OkHttpClientBuilder.getBuilder().proxy(proxy.getProxy()).proxyAuthenticator(proxy.getAuth()).build();
             }
         }
     }

--- a/src/main/java/com/binance/connector/client/utils/httpclient/OkHttpClientBuilder.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/OkHttpClientBuilder.java
@@ -2,8 +2,17 @@ package com.binance.connector.client.utils.httpclient;
 
 import okhttp3.OkHttpClient;
 
-import java.time.Duration;
+public final class OkHttpClientBuilder {
+    private static OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
-public class OkHttpClientBuilder {
-    public static OkHttpClient.Builder builder = new OkHttpClient.Builder().pingInterval(Duration.ofSeconds(10));
+    private OkHttpClientBuilder() {
+    }
+
+    public static void setBuilder(OkHttpClient.Builder builder) {
+        OkHttpClientBuilder.builder = builder;
+    }
+
+    public static OkHttpClient.Builder getBuilder() {
+        return builder;
+    }
 }

--- a/src/main/java/com/binance/connector/client/utils/httpclient/OkHttpClientBuilder.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/OkHttpClientBuilder.java
@@ -1,0 +1,9 @@
+package com.binance.connector.client.utils.httpclient;
+
+import okhttp3.OkHttpClient;
+
+import java.time.Duration;
+
+public class OkHttpClientBuilder {
+    public static OkHttpClient.Builder builder = new OkHttpClient.Builder().pingInterval(Duration.ofSeconds(10));
+}

--- a/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketApiHttpClientSingleton.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketApiHttpClientSingleton.java
@@ -3,7 +3,7 @@ package com.binance.connector.client.utils.httpclient;
 import okhttp3.OkHttpClient;
 
 public final class WebSocketApiHttpClientSingleton {
-    private static final OkHttpClient httpClient = new OkHttpClient(OkHttpClientBuilder.builder);
+    private static final OkHttpClient httpClient = new OkHttpClient(OkHttpClientBuilder.getBuilder());
 
     private WebSocketApiHttpClientSingleton() {
     }

--- a/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketApiHttpClientSingleton.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketApiHttpClientSingleton.java
@@ -3,7 +3,7 @@ package com.binance.connector.client.utils.httpclient;
 import okhttp3.OkHttpClient;
 
 public final class WebSocketApiHttpClientSingleton {
-    private static final OkHttpClient httpClient = new OkHttpClient();
+    private static final OkHttpClient httpClient = new OkHttpClient(OkHttpClientBuilder.builder);
 
     private WebSocketApiHttpClientSingleton() {
     }

--- a/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketStreamHttpClientSingleton.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketStreamHttpClientSingleton.java
@@ -3,7 +3,7 @@ package com.binance.connector.client.utils.httpclient;
 import okhttp3.OkHttpClient;
 
 public final class WebSocketStreamHttpClientSingleton {
-    private static final OkHttpClient httpClient = new OkHttpClient(OkHttpClientBuilder.builder);
+    private static final OkHttpClient httpClient = new OkHttpClient(OkHttpClientBuilder.getBuilder());
 
     private WebSocketStreamHttpClientSingleton() {
     }

--- a/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketStreamHttpClientSingleton.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketStreamHttpClientSingleton.java
@@ -3,7 +3,7 @@ package com.binance.connector.client.utils.httpclient;
 import okhttp3.OkHttpClient;
 
 public final class WebSocketStreamHttpClientSingleton {
-    private static final OkHttpClient httpClient = new OkHttpClient();
+    private static final OkHttpClient httpClient = new OkHttpClient(OkHttpClientBuilder.builder);
 
     private WebSocketStreamHttpClientSingleton() {
     }


### PR DESCRIPTION
A new static OkHttpClientBuilder object has been added. It defines default OkHttpClient.Builder. 

We can change the settings of OkHttpClient as on that sample:
__OkHttpClientBuilder.setBuilder(new_ OkHttpClient.Builder().pingInterval(Duration.ofSeconds(10)));_

 This must be done before static objects *ClientSingleton are initialized.
