### PR TITLE
Added RetryAfter header handler

### DIFF
--- a/src/main/java/com/binance/connector/client/exceptions/BinanceClientException.java
+++ b/src/main/java/com/binance/connector/client/exceptions/BinanceClientException.java
@@ -6,6 +6,7 @@ public class BinanceClientException extends RuntimeException {
     private final int httpStatusCode;
     private final int errorCode;
     private String errMsg;
+    private int retryAfter;
 
     public BinanceClientException(String fullErrMsg, int httpStatusCode) {
         super(fullErrMsg);
@@ -19,6 +20,11 @@ public class BinanceClientException extends RuntimeException {
         this.errorCode = errorCode;
         this.errMsg =  errMsg;
     }
+    
+    public BinanceClientException(String fullErrMsg, String errMsg, int httpStatusCode, int errorCode, int retryAfter) {
+        this(fullErrMsg, errMsg, httpStatusCode, errorCode);
+        this.retryAfter = retryAfter;
+    }
 
     public int getErrorCode() {
         return errorCode;
@@ -30,5 +36,9 @@ public class BinanceClientException extends RuntimeException {
 
     public String getErrMsg() {
         return errMsg;
+    }
+    
+    public int getRetryAfter() {
+    	return retryAfter;
     }
 }


### PR DESCRIPTION
Based on official API documentation [here ](https://binance-docs.github.io/apidocs/spot/en/#limits) for limits, in the case of HttpStatusCode 429 or 418 the header retry-after is provided in the response headers.
The header would be very helpful in case a limit is reached to know how much time it is necessary to wait for a new request so I implemented a handler to add this header to the BinanceClientException.