### PR TITLE
Rc v.3.2.1 - Following the latest upgrade on Binance Loans

### DIFF
--- a/src/main/java/com/binance/connector/client/impl/spot/CryptoLoans.java
+++ b/src/main/java/com/binance/connector/client/impl/spot/CryptoLoans.java
@@ -380,10 +380,10 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#borrow-get-flexible-loan-borrow-history-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#borrow-get-flexible-loan-borrow-history-user_data</a>
      */
-    @Deprecated
     public String flexibleLoanBorrowHistory(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_BORROW_HISTORY, parameters, HttpMethod.GET, showLimitUsage);
     }
+
     private final String FLEXIBLE_LOAN_BORROW_HISTORY_V2 = "/sapi/v2/loan/flexible/borrow/history";
     public String flexibleLoanBorrowHistoryV2(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_BORROW_HISTORY_V2, parameters, HttpMethod.GET, showLimitUsage);
@@ -443,7 +443,6 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#repay-get-flexible-loan-repayment-history-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#repay-get-flexible-loan-repayment-history-user_data</a>
      */
-    @Deprecated
     public String flexibleLoanRepayHistory(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_REPAY_HISTORY, parameters, HttpMethod.GET, showLimitUsage);
     }
@@ -507,7 +506,6 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#adjust-ltv-get-flexible-loan-ltv-adjustment-history-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#adjust-ltv-get-flexible-loan-ltv-adjustment-history-user_data</a>
      */
-    @Deprecated
     public String flexibleLoanLtvAdjustHistory(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_LTV_ADJUST_HISTORY, parameters, HttpMethod.GET, showLimitUsage);
     }

--- a/src/main/java/com/binance/connector/client/impl/spot/CryptoLoans.java
+++ b/src/main/java/com/binance/connector/client/impl/spot/CryptoLoans.java
@@ -81,7 +81,7 @@ public class CryptoLoans {
         ParameterChecker.checkParameter(parameters, "loanTerm", Integer.class);
         return requestHandler.sendSignedRequest(baseUrl, LOAN_BORROW, parameters, HttpMethod.POST, showLimitUsage);
     }
-    
+
     private final String LOAN_BORROW_HISTORY = "/sapi/v1/loan/borrow/history";
     /**
      * GET /sapi/v1/loan/borrow/history
@@ -196,7 +196,7 @@ public class CryptoLoans {
         ParameterChecker.checkRequiredParameter(parameters, "amount");
         return requestHandler.sendSignedRequest(baseUrl, LOAN_ADJUST_LTV, parameters, HttpMethod.POST, showLimitUsage);
     }
-    
+
     private final String LOAN_ADJUST_LTV_HISTORY = "/sapi/v1/loan/ltv/adjustment/history";
     /**
      * GET /sapi/v1/loan/ltv/adjustment/history
@@ -320,10 +320,18 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#borrow-flexible-loan-borrow-trade">
      *      https://binance-docs.github.io/apidocs/spot/en/#borrow-flexible-loan-borrow-trade</a>
      */
+    @Deprecated
     public String flexibleLoanBorrow(Map<String, Object> parameters) {
         ParameterChecker.checkParameter(parameters, "loanCoin", String.class);
         ParameterChecker.checkParameter(parameters, "collateralCoin", String.class);
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_BORROW, parameters, HttpMethod.POST, showLimitUsage);
+    }
+
+    private final String FLEXIBLE_LOAN_BORROW_V2 = "/sapi/v2/loan/flexible/borrow";
+    public String flexibleLoanBorrowV2(Map<String, Object> parameters) {
+        ParameterChecker.checkParameter(parameters, "loanCoin", String.class);
+        ParameterChecker.checkParameter(parameters, "collateralCoin", String.class);
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_BORROW_V2, parameters, HttpMethod.POST, showLimitUsage);
     }
 
     private final String FLEXIBLE_LOAN_ONGOING_ORDERS = "/sapi/v1/loan/flexible/ongoing/orders";
@@ -343,8 +351,14 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#borrow-get-flexible-loan-ongoing-orders-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#borrow-get-flexible-loan-ongoing-orders-user_data</a>
      */
+    @Deprecated
     public String flexibleLoanOngoingOrders(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_ONGOING_ORDERS, parameters, HttpMethod.GET, showLimitUsage);
+    }
+
+    private final String FLEXIBLE_LOAN_ONGOING_ORDERS_V2 = "/sapi/v2/loan/flexible/ongoing/orders";
+    public String flexibleLoanOngoingOrdersV2(Map<String, Object> parameters) {
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_ONGOING_ORDERS_V2, parameters, HttpMethod.GET, showLimitUsage);
     }
 
     private final String FLEXIBLE_LOAN_BORROW_HISTORY = "/sapi/v1/loan/flexible/borrow/history";
@@ -366,8 +380,13 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#borrow-get-flexible-loan-borrow-history-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#borrow-get-flexible-loan-borrow-history-user_data</a>
      */
+    @Deprecated
     public String flexibleLoanBorrowHistory(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_BORROW_HISTORY, parameters, HttpMethod.GET, showLimitUsage);
+    }
+    private final String FLEXIBLE_LOAN_BORROW_HISTORY_V2 = "/sapi/v2/loan/flexible/borrow/history";
+    public String flexibleLoanBorrowHistoryV2(Map<String, Object> parameters) {
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_BORROW_HISTORY_V2, parameters, HttpMethod.GET, showLimitUsage);
     }
 
     private final String FLEXIBLE_LOAN_REPAY = "/sapi/v1/loan/flexible/repay";
@@ -388,11 +407,21 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#repay-flexible-loan-repay-trade">
      *      https://binance-docs.github.io/apidocs/spot/en/#repay-flexible-loan-repay-trade</a>
      */
+    @Deprecated
     public String flexibleLoanRepay(Map<String, Object> parameters) {
         ParameterChecker.checkParameter(parameters, "loanCoin", String.class);
         ParameterChecker.checkParameter(parameters, "collateralCoin", String.class);
         ParameterChecker.checkRequiredParameter(parameters, "repayAmount");
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_REPAY, parameters, HttpMethod.POST, showLimitUsage);
+    }
+
+    private final String FLEXIBLE_LOAN_REPAY_V2 = "/sapi/v2/loan/flexible/repay";
+
+    public String flexibleLoanRepayV2(Map<String, Object> parameters) {
+        ParameterChecker.checkParameter(parameters, "loanCoin", String.class);
+        ParameterChecker.checkParameter(parameters, "collateralCoin", String.class);
+        ParameterChecker.checkRequiredParameter(parameters, "repayAmount");
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_REPAY_V2, parameters, HttpMethod.POST, showLimitUsage);
     }
 
     private final String FLEXIBLE_LOAN_REPAY_HISTORY = "/sapi/v1/loan/flexible/repay/history";
@@ -414,8 +443,14 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#repay-get-flexible-loan-repayment-history-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#repay-get-flexible-loan-repayment-history-user_data</a>
      */
+    @Deprecated
     public String flexibleLoanRepayHistory(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_REPAY_HISTORY, parameters, HttpMethod.GET, showLimitUsage);
+    }
+
+    private final String FLEXIBLE_LOAN_REPAY_HISTORY_V2 = "/sapi/v2/loan/flexible/repay/history";
+    public String flexibleLoanRepayHistoryV2(Map<String, Object> parameters) {
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_REPAY_HISTORY_V2, parameters, HttpMethod.GET, showLimitUsage);
     }
 
     private final String FLEXIBLE_LOAN_ADJUST_LTV = "/sapi/v1/loan/flexible/adjust/ltv";
@@ -435,12 +470,22 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#adjust-ltv-flexible-loan-adjust-ltv-trade">
      *      https://binance-docs.github.io/apidocs/spot/en/#adjust-ltv-flexible-loan-adjust-ltv-trade</a>
      */
+    @Deprecated
     public String flexibleLoanAdjustLtv(Map<String, Object> parameters) {
         ParameterChecker.checkParameter(parameters, "loanCoin", String.class);
         ParameterChecker.checkParameter(parameters, "collateralCoin", String.class);
         ParameterChecker.checkRequiredParameter(parameters, "adjustmentAmount");
         ParameterChecker.checkParameter(parameters, "direction", String.class);
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_ADJUST_LTV, parameters, HttpMethod.POST, showLimitUsage);
+    }
+    private final String FLEXIBLE_LOAN_ADJUST_LTV_V2 = "/sapi/v2/loan/flexible/adjust/ltv";
+
+    public String flexibleLoanAdjustLtvV2(Map<String, Object> parameters) {
+        ParameterChecker.checkParameter(parameters, "loanCoin", String.class);
+        ParameterChecker.checkParameter(parameters, "collateralCoin", String.class);
+        ParameterChecker.checkRequiredParameter(parameters, "adjustmentAmount");
+        ParameterChecker.checkParameter(parameters, "direction", String.class);
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_ADJUST_LTV_V2, parameters, HttpMethod.POST, showLimitUsage);
     }
 
     private final String FLEXIBLE_LOAN_LTV_ADJUST_HISTORY = "/sapi/v1/loan/flexible/ltv/adjustment/history";
@@ -462,14 +507,19 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#adjust-ltv-get-flexible-loan-ltv-adjustment-history-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#adjust-ltv-get-flexible-loan-ltv-adjustment-history-user_data</a>
      */
+    @Deprecated
     public String flexibleLoanLtvAdjustHistory(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_LTV_ADJUST_HISTORY, parameters, HttpMethod.GET, showLimitUsage);
     }
 
+    private final String FLEXIBLE_LOAN_LTV_ADJUST_HISTORY_V2 = "/sapi/v2/loan/flexible/ltv/adjustment/history";
+    public String flexibleLoanLtvAdjustHistoryV2(Map<String, Object> parameters) {
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_LTV_ADJUST_HISTORY_V2, parameters, HttpMethod.GET, showLimitUsage);
+    }
     private final String FLEXIBLE_LOAN_ASSETS = "/sapi/v1/loan/flexible/loanable/data";
     /**
      * Get interest rate and borrow limit of flexible loanable assets. The borrow limit is shown in USD value.
-     * 
+     *
      * <br><br>
      * GET /sapi/v1/loan/flexible/loanable/data
      * <br>
@@ -483,14 +533,20 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#get-flexible-loan-assets-data-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#get-flexible-loan-assets-data-user_data</a>
      */
+    @Deprecated
     public String flexibleLoanAssets(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_ASSETS, parameters, HttpMethod.GET, showLimitUsage);
     }
+    private final String FLEXIBLE_LOAN_ASSETS_V2 = "/sapi/v2/loan/flexible/loanable/data";
+    public String flexibleLoanAssetsV2(Map<String, Object> parameters) {
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_ASSETS_V2, parameters, HttpMethod.GET, showLimitUsage);
+    }
+
 
     private final String FLEXIBLE_LOAN_COLLATERAL_ASSETS = "/sapi/v1/loan/flexible/collateral/data";
     /**
      * Get LTV information and collateral limit of flexible loan's collateral assets. The collateral limit is shown in USD value.
-     * 
+     *
      * <br><br>
      * GET /sapi/v1/loan/flexible/collateral/data
      * <br>
@@ -504,7 +560,14 @@ public class CryptoLoans {
      * @see <a href="https://binance-docs.github.io/apidocs/spot/en/#get-flexible-loan-collateral-assets-data-user_data">
      *      https://binance-docs.github.io/apidocs/spot/en/#get-flexible-loan-collateral-assets-data-user_data</a>
      */
+    @Deprecated
     public String flexibleLoanCollateralAssets(Map<String, Object> parameters) {
         return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_COLLATERAL_ASSETS, parameters, HttpMethod.GET, showLimitUsage);
     }
+
+    private final String FLEXIBLE_LOAN_COLLATERAL_ASSETS_V2 = "/sapi/v2/loan/flexible/collateral/data";
+    public String flexibleLoanCollateralAssetsV2(Map<String, Object> parameters) {
+        return requestHandler.sendSignedRequest(baseUrl, FLEXIBLE_LOAN_COLLATERAL_ASSETS_V2, parameters, HttpMethod.GET, showLimitUsage);
+    }
+
 }


### PR DESCRIPTION
Added

- Binance Loans has added the following /v2 SAPI endpoints at 2024-02-27 08:00 (UTC). Users may utilize v2 SAPI endpoints to place, repay, and manage new Binance Loans (Flexible Rate) orders created after 2024-02-27 08:00 (UTC).
  - `POST /sapi/v2/loan/flexible/borrow`
  - `GET /sapi/v2/loan/flexible/ongoing/orders`
  - `GET /sapi/v2/loan/flexible/borrow/history`
  - `POST /sapi/v2/loan/flexible/repay`
  - `GET /sapi/v2/loan/flexible/repay/history`
  - `POST /sapi/v2/loan/flexible/adjust/ltv`
  - `GET /sapi/v2/loan/flexible/ltv/adjustment/history`
  - `GET /sapi/v2/loan/flexible/loanable/data`
  - `GET /sapi/v2/loan/flexible/collateral/data`

Deprecated

- In addition, Binance Loans will be retiring its /v1 SAPI endpoints at the following timings.(deprecated)
  - `POST /sapi/v1/loan/flexible/borrow`
  - `GET /sapi/v1/loan/flexible/loanable/data`
  - `GET /sapi/v1/loan/flexible/collateral/data`
  - `GET /sapi/v1/loan/flexible/ongoing/orders`
  - `POST /sapi/v1/loan/flexible/repay`
  - `POST /sapi/v1/loan/flexible/adjust/ltv`
