### PR TITLE
feat(websocket): support proxy

### DIFF
--- a/src/main/java/com/binance/connector/client/WebSocketStreamClient.java
+++ b/src/main/java/com/binance/connector/client/WebSocketStreamClient.java
@@ -1,5 +1,6 @@
 package com.binance.connector.client;
 
+import com.binance.connector.client.utils.ProxyAuth;
 import java.util.ArrayList;
 
 import com.binance.connector.client.utils.websocketcallback.WebSocketClosedCallback;
@@ -39,4 +40,5 @@ public interface WebSocketStreamClient {
     int combineStreams(ArrayList<String> streams, WebSocketOpenCallback onOpenCallback, WebSocketMessageCallback onMessageCallback, WebSocketClosingCallback onClosingCallback, WebSocketClosedCallback onClosedCallback, WebSocketFailureCallback onFailureCallback);
     void closeConnection(int streamId);
     void closeAllConnections();
+    void setProxy(ProxyAuth proxy);
 }

--- a/src/main/java/com/binance/connector/client/impl/WebSocketStreamClientImpl.java
+++ b/src/main/java/com/binance/connector/client/impl/WebSocketStreamClientImpl.java
@@ -1,5 +1,6 @@
 package com.binance.connector.client.impl;
 
+import com.binance.connector.client.utils.ProxyAuth;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,7 +37,7 @@ import okhttp3.Request;
  */
 public class WebSocketStreamClientImpl implements WebSocketStreamClient {
     private static final Logger logger = LoggerFactory.getLogger(WebSocketStreamClientImpl.class);
-    private static final OkHttpClient client = WebSocketStreamHttpClientSingleton.getHttpClient();
+    private static OkHttpClient client = WebSocketStreamHttpClientSingleton.getHttpClient();
     private final String baseUrl;
     private final Map<Integer, WebSocketConnection> connections = new HashMap<>();
     private final WebSocketOpenCallback noopOpenCallback = response -> { };
@@ -598,6 +599,11 @@ public class WebSocketStreamClientImpl implements WebSocketStreamClient {
             client.dispatcher().executorService().shutdown();
             logger.info("All connections are closed!");
         }
+    }
+
+    @Override
+    public void setProxy(ProxyAuth proxy) {
+        client = WebSocketStreamHttpClientSingleton.getHttpClientWithProxy(proxy);
     }
 
     private int createConnection(

--- a/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketStreamHttpClientSingleton.java
+++ b/src/main/java/com/binance/connector/client/utils/httpclient/WebSocketStreamHttpClientSingleton.java
@@ -1,15 +1,38 @@
 package com.binance.connector.client.utils.httpclient;
 
+import com.binance.connector.client.utils.ProxyAuth;
 import okhttp3.OkHttpClient;
 
 public final class WebSocketStreamHttpClientSingleton {
-    private static final OkHttpClient httpClient = new OkHttpClient();
 
-    private WebSocketStreamHttpClientSingleton() {
-    }
+  private static OkHttpClient httpClient = null;
 
-    public static OkHttpClient getHttpClient() {
-        return httpClient;
+  private WebSocketStreamHttpClientSingleton() {
+  }
+
+  public static OkHttpClient getHttpClient() {
+    if (httpClient == null) {
+      httpClient = new OkHttpClient();
     }
+    return httpClient;
+  }
+
+  public static OkHttpClient getHttpClientWithProxy(ProxyAuth proxy) {
+    createClientWithProxy(proxy);
+    return httpClient;
+  }
+
+  public static void createClientWithProxy(ProxyAuth proxy) {
+    if (proxy == null) {
+      httpClient = new OkHttpClient();
+    } else {
+      if (proxy.getAuth() == null) {
+        httpClient = new OkHttpClient.Builder().proxy(proxy.getProxy()).build();
+      } else {
+        httpClient = new OkHttpClient.Builder().proxy(proxy.getProxy())
+            .proxyAuthenticator(proxy.getAuth()).build();
+      }
+    }
+  }
 
 }


### PR DESCRIPTION
Update `WebSocketStreamClient` to support proxy：
Introduces a new interface to enable proxy support for WebSocket connections like the spot interface did