### PR TITLE
Changes to handle List parameter in UrlBuilder

### DIFF
--- a/src/main/java/com/binance/connector/client/utils/UrlBuilder.java
+++ b/src/main/java/com/binance/connector/client/utils/UrlBuilder.java
@@ -7,8 +7,10 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 public final class UrlBuilder {
@@ -63,6 +65,9 @@ public final class UrlBuilder {
                 String value;
                 if (params.get(key) instanceof Double) {
                     value = getFormatter().format(params.get(key));
+                } else if (params.get(key) instanceof List) {
+                    List list = (List) params.get(key);
+                    value = list.stream().map(Object::toString).collect(Collectors.joining(","));
                 } else {
                     value = params.get(key).toString();
                 }


### PR DESCRIPTION

When you need to pass an argument of List type, for example in Wallet class for com.koinbasket.common.binance.Wallet#dustTransfer, the UrlBuilder does not work properly. It has only handling for Double type and in else block it considers everything to work with toString. In case of list argument it forms bad value for the parameter.


This PR fixes: https://github.com/binance/binance-connector-java/issues/119