### PR TITLE
Feature/Optional time supplier

### DIFF
--- a/src/main/java/com/binance/connector/client/SpotClient.java
+++ b/src/main/java/com/binance/connector/client/SpotClient.java
@@ -23,11 +23,13 @@ import com.binance.connector.client.impl.spot.VIPLoans;
 import com.binance.connector.client.impl.spot.Wallet;
 import com.binance.connector.client.utils.ProxyAuth;
 
+import java.util.function.Supplier;
 
 public interface SpotClient {
     void setShowLimitUsage(boolean showLimitUsage);
     void setProxy(ProxyAuth proxy);
     void unsetProxy();
+    void setTimeSupplier(Supplier<Long> timeSupplier);
     AutoInvest createAutoInvest();
     C2C createC2C();
     Convert createConvert();

--- a/src/main/java/com/binance/connector/client/impl/SpotClientImpl.java
+++ b/src/main/java/com/binance/connector/client/impl/SpotClientImpl.java
@@ -24,8 +24,11 @@ import com.binance.connector.client.impl.spot.UserData;
 import com.binance.connector.client.impl.spot.VIPLoans;
 import com.binance.connector.client.impl.spot.Wallet;
 import com.binance.connector.client.utils.ProxyAuth;
+import com.binance.connector.client.utils.TimeSupplier;
 import com.binance.connector.client.utils.signaturegenerator.HmacSignatureGenerator;
 import com.binance.connector.client.utils.signaturegenerator.SignatureGenerator;
+
+import java.util.function.Supplier;
 
 public class SpotClientImpl implements SpotClient {
     private final String apiKey;
@@ -69,6 +72,11 @@ public class SpotClientImpl implements SpotClient {
     @Override
     public void setProxy(ProxyAuth proxy) {
         this.proxy = proxy;
+    }
+
+    @Override
+    public void setTimeSupplier(Supplier<Long> timeSupplier) {
+        TimeSupplier.INSTANCE.setTimeProvider(timeSupplier);
     }
     
     @Override

--- a/src/main/java/com/binance/connector/client/utils/RequestHandler.java
+++ b/src/main/java/com/binance/connector/client/utils/RequestHandler.java
@@ -56,7 +56,7 @@ public class RequestHandler {
         }
 
         parameters = (parameters == null) ? new HashMap<String, Object>() : parameters;
-        parameters.putIfAbsent("timestamp", UrlBuilder.buildTimestamp());
+        parameters.putIfAbsent("timestamp", TimeSupplier.INSTANCE.buildTimestamp());
         parameters.put("signature", this.signatureGenerator.getSignature(UrlBuilder.joinQueryParameters(parameters)));
 
         String fullUrl = UrlBuilder.buildFullUrl(baseUrl, urlPath, parameters);

--- a/src/main/java/com/binance/connector/client/utils/TimeSupplier.java
+++ b/src/main/java/com/binance/connector/client/utils/TimeSupplier.java
@@ -1,0 +1,22 @@
+package com.binance.connector.client.utils;
+
+import java.util.function.Supplier;
+
+public class TimeSupplier {
+
+    public static final TimeSupplier INSTANCE = new TimeSupplier();
+
+    private Supplier<Long> timeProvider;
+
+    public TimeSupplier() {
+        timeProvider = System::currentTimeMillis;
+    }
+
+    public void setTimeProvider(Supplier<Long> timeProvider) {
+        this.timeProvider = timeProvider;
+    }
+
+    public String buildTimestamp() {
+        return String.valueOf(timeProvider.get());
+    }
+}

--- a/src/main/java/com/binance/connector/client/utils/websocketapi/WebSocketApiRequestHandler.java
+++ b/src/main/java/com/binance/connector/client/utils/websocketapi/WebSocketApiRequestHandler.java
@@ -6,6 +6,7 @@ import com.binance.connector.client.utils.JSONParser;
 import com.binance.connector.client.utils.ParameterChecker;
 import com.binance.connector.client.utils.UrlBuilder;
 import com.binance.connector.client.utils.WebSocketConnection;
+import com.binance.connector.client.utils.TimeSupplier;
 import com.binance.connector.client.utils.signaturegenerator.SignatureGenerator;
 
 import org.json.JSONObject;
@@ -60,7 +61,7 @@ public class WebSocketApiRequestHandler {
                 ParameterChecker.checkParameterType(this.apiKey, String.class, "apiKey");
                 parameters = JSONParser.addKeyValue(parameters, "apiKey", this.apiKey);
                 if (!parameters.has("timestamp")) {
-                    parameters.put("timestamp", UrlBuilder.buildTimestamp());
+                    parameters.put("timestamp", TimeSupplier.INSTANCE.buildTimestamp());
                 }
 
                 // signature


### PR DESCRIPTION
### Background

When developing locally my clock gets out of sync pretty fast and it was getting unwieldly to develop. I forked and used this locally to get around my problem. I thought it might be of use to other people as well.

![local_development_clocks](https://github.com/user-attachments/assets/722f019c-334e-42ef-acfc-b569761d8967)

### Solution

Add a `TimeSupplier` class which can be passed a custom long supplier which can be used to adjust the time.

### Potential usage

```
public class BinanceRestAdapter implements VenueAdapter {
    private final SpotClient client;

    public BinanceRestAdapter(String baseUrl, String apiKey, String privateKey, ObjectMapper objectMapper, List<String> tradingCoins) {
        client = new SpotClientImpl(apiKey, privateKey, baseUrl);
        client.setTimeSupplier(SysTime.INSTANCE::currentTimeMillis);
        syncTime();
    }

    ...

    private void syncTime() {
        String timeResult = client.createMarket().time();
        Long serverTimerTime = Long.valueOf(timeResult.substring(14, timeResult.length() - 1));
        Long clientTime = System.currentTimeMillis();
        long delta = clientTime - serverTimerTime;
        SysTime.INSTANCE.setDelta(-delta);
        Long updatedTime = SysTime.INSTANCE.currentTimeMillis();
        LOG.info(String.format("Updating @ local time %s | external time %s (%s ms) | new time delta = %s", clientTime, serverTimerTime, delta, updatedTime - serverTimerTime));
    }
}
```

With a class something like this 

```
public class SysTime {
    public static SysTime INSTANCE = new SysTime();
    private long delta;

    public long currentTimeMillis() {
        return System.currentTimeMillis() + delta;
    }

    public void setDelta(long delta) {
        this.delta = delta;
    }
}
```